### PR TITLE
Handle gzipped log files, with dates in filenames.

### DIFF
--- a/processlogs.php
+++ b/processlogs.php
@@ -268,6 +268,7 @@ function extractData($logsFolder, $startDate, $endDate){
             $buf = gzdecode($buf);
         }
         $lines = explode(PHP_EOL, $buf);
+        unset($buf);
 
         foreach ($lines as $line) {
 

--- a/processlogs.php
+++ b/processlogs.php
@@ -253,7 +253,7 @@ function generateList($beacons) {
 function extractData($logsFolder, $startDate, $endDate){
 
     $beacons = [];
-    $filenames = glob("{$logsFolder}console.log*");
+    $filenames = glob("{$logsFolder}console*.log*");
 
     if (empty($filenames)){
         exit ("No logs found. Please chdir to the Helium miner logs folder or specify a path.\n");

--- a/processlogs.php
+++ b/processlogs.php
@@ -263,7 +263,11 @@ function extractData($logsFolder, $startDate, $endDate){
 
     foreach ($filenames as $filename) {
 
-        $lines = file( $filename, FILE_IGNORE_NEW_LINES);
+        $buf = file_get_contents($filename);
+        if(substr($filename, -3) == '.gz') {
+            $buf = gzdecode($buf);
+        }
+        $lines = explode(PHP_EOL, $buf);
 
         foreach ($lines as $line) {
 


### PR DESCRIPTION
I have a system that automatically collects logs from all my Sensecap's onto a management server. For this to be a bit more tidy I store my logs as `.../HOSTNAME/PREFIX_YYYY-MM-DD.log.gz` (example: `.../helium-01/console_2022-03-27.log.gz`).

Here are two commits that allows this. First commit just adds an asterix to the filename glob so that logs with the date in them can be found. Second commit allows to open, and decompress, gzipped files. Also added a third commit which unsets a temporary variable to save some increased memory usage I caused.

I have intentionally used `substr` to detect if the filename is `.gz` instead of using `str_ends_with` from PHP 8.x, to keep backwards compatibility. None of the patches provide should give and negative impact to any existing use cases.

Please consider accepting this pull request to keep the patches in the original branch. Thank you.